### PR TITLE
Fix compile error in test suite.

### DIFF
--- a/tests/Control/Timeout/Tests.hs
+++ b/tests/Control/Timeout/Tests.hs
@@ -20,7 +20,7 @@ newtype SmallInterval = SmallInterval NominalDiffTime
     deriving (Show)
 
 instance Arbitrary SmallInterval where
-    arbitrary = fmap (SmallInterval . getPositive) $ suchThat arbitrary (< 1000)
+    arbitrary = fmap (SmallInterval . getPositive) $ suchThat arbitrary (< Positive 1000)
 
 instance Arbitrary NominalDiffTime where
     arbitrary = fmap fromInteger arbitrary


### PR DESCRIPTION
Thanks for the new version - unfortunately the test suite doesn't compile for me: 

tests/Control/Timeout/Tests.hs:23:76:
    No instance for (Num (Positive NominalDiffTime))
      arising from the literal ‘1000’
    In the second argument of ‘(<)’, namely ‘1000’
    In the second argument of ‘suchThat’, namely ‘(< 1000)’
    In the second argument of ‘($)’, namely
      ‘suchThat arbitrary (< 1000)’

This change fixes it.
